### PR TITLE
Fix missing #pragma decl for streams.h

### DIFF
--- a/stitch/streams.h
+++ b/stitch/streams.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "connections.h"
 #include "queue_mpsc_waitfree.h"
 #include "signal.h"


### PR DESCRIPTION
Looks like the `#pragma once` was missing which caused the compiler to complain.