### PR TITLE
Fix sample code method name

### DIFF
--- a/doc/examples/stream-events.cpp
+++ b/doc/examples/stream-events.cpp
@@ -26,7 +26,7 @@ auto consumer_func = [&]()
     int count = 0;
     while(count < 10)
     {
-        wait(consumer.event());
+        wait(consumer.receive_event());
 
         Notification notification;
         while(consumer.pop(notification))


### PR DESCRIPTION
Looks like the consumer should have it's `receive_event` method called instead. :)